### PR TITLE
Thermostat Schedule Proto Definitions

### DIFF
--- a/proto/iot.proto
+++ b/proto/iot.proto
@@ -139,7 +139,7 @@ message ThermostatScheduleBlock {
     //Current system mode of thermostat
     //unit: xbos/iot/HVACMode
     HVACMode mode = 3;
-    //Time of schedule retrieval
+    //Time when schedule block takes effect
     //format: RFC
     string time = 4;
 }

--- a/proto/iot.proto
+++ b/proto/iot.proto
@@ -41,6 +41,13 @@ enum HVACState {
     HVACStateCoolStage2 = 4;
 }
 
+enum SystemMode {
+    SystemAuto = 0;
+    SystemHeat = 1;
+    SystemCool = 2;
+    SystemOff = 3;
+}
+
 message XBOSIoTDeviceState {
     // current time at device/service
     //unit:ns
@@ -117,6 +124,34 @@ message Thermostat {
     //cooling setpoint
     //unit: celsius
     Double cooling_setpoint = 11;
+}
+
+//Schedule of one week
+message Schedule {
+    //Map day of week to schedule
+    map<string, ScheduleDay> scheduleMap = 1;
+}
+
+// Repeated Schedule Wrapper
+message ScheduleDay {
+    //Series of Schedule Blocks
+    repeated ScheduleBlock blocks = 1;
+}
+
+// Schedule Block
+message ScheduleBlock {
+    //heating setpoint
+    //unit: celsius
+    Double heat_setting = 1;
+    //cooling setpoint
+    //unit: celsius
+    Double cool_setting = 2;
+    //Current system mode of thermostat
+    //unit: xbos/iot/SystemMode
+    SystemMode mode = 3;
+    //Time of schedule retrieval
+    //format: RFC
+    string time = 4;
 }
 
 message Meter {

--- a/proto/iot.proto
+++ b/proto/iot.proto
@@ -41,13 +41,6 @@ enum HVACState {
     HVACStateCoolStage2 = 4;
 }
 
-enum SystemMode {
-    SystemAuto = 0;
-    SystemHeat = 1;
-    SystemCool = 2;
-    SystemOff = 3;
-}
-
 message XBOSIoTDeviceState {
     // current time at device/service
     //unit:ns
@@ -126,29 +119,26 @@ message Thermostat {
     Double cooling_setpoint = 11;
 }
 
-//Schedule of one week
-message Schedule {
-    //Map day of week to schedule
+message ThermostatSchedule {
+    //Map day of week to daily schedule
     map<string, ScheduleDay> scheduleMap = 1;
 }
 
-// Repeated Schedule Wrapper
-message ScheduleDay {
-    //Series of Schedule Blocks
+message ThermostatScheduleDay {
+    //Daily schedule is Multiple Blocks
     repeated ScheduleBlock blocks = 1;
 }
 
-// Schedule Block
-message ScheduleBlock {
+message ThermostatScheduleBlock {
     //heating setpoint
     //unit: celsius
-    Double heat_setting = 1;
+    Double heating_setpoint = 1;
     //cooling setpoint
     //unit: celsius
-    Double cool_setting = 2;
+    Double cooling_setpoint = 2;
     //Current system mode of thermostat
-    //unit: xbos/iot/SystemMode
-    SystemMode mode = 3;
+    //unit: xbos/iot/HVACMode
+    HVACMode mode = 3;
     //Time of schedule retrieval
     //format: RFC
     string time = 4;

--- a/proto/iot.proto
+++ b/proto/iot.proto
@@ -140,7 +140,7 @@ message ThermostatScheduleBlock {
     //unit: xbos/iot/HVACMode
     HVACMode mode = 3;
     //Time when schedule block takes effect
-    //format: RFC 3339
+    //format: RRule
     string time = 4;
 }
 

--- a/proto/iot.proto
+++ b/proto/iot.proto
@@ -140,7 +140,7 @@ message ThermostatScheduleBlock {
     //unit: xbos/iot/HVACMode
     HVACMode mode = 3;
     //Time when schedule block takes effect
-    //format: RFC
+    //format: RFC 3339
     string time = 4;
 }
 


### PR DESCRIPTION
This pull request intends to add the proto messages for defining a thermostat's schedule. Specifically, it adds one new enum and three new messages to the existing iot.proto file. The fields of and relationships between the schedule structs are written in the image of the existing Pelican thermostat drivers that worked with the previous version of XBOS and BW2.

To properly reflect creating a map with a value type that is a list, I defined three messages
1. ScheduleBlock contains the heat, cool, system, and time settings for a particular block.
2. ScheduleDay captures the idea of a series/list of ScheduleBlocks as a day's schedule.
3. Schedule maps every day of the week to an individual ScheduleDay.

I consulted this stack overflow [post](https://stackoverflow.com/questions/38886789/protobuf3-how-to-describe-map-of-repeated-string) that provides some explanations regarding my design choices.