### PR TITLE
New Fields for Meter Message

### DIFF
--- a/proto/iot.proto
+++ b/proto/iot.proto
@@ -155,26 +155,26 @@ message DemandResponseEvent {
 }
 
 message Meter {
-    option (brick_equip_class).namespace = 'https://brickschema.org/schema/1.0.3/Brick#brick';
+    option (brick_equip_class).namespace = 'https://brickschema.org/schema/1.0.3/Brick#';
     option (brick_equip_class).value = 'Meter';
     //unit: kW
-    Double power = 1 [(brick_point_class).namespace='https://brickschema.org/schema/1.0.3/Brick#brick', (brick_point_class).value='Power_Sensor'];
+    Double power = 1 [(brick_point_class).namespace='https://brickschema.org/schema/1.0.3/Brick#', (brick_point_class).value='Power_Sensor'];
     //unit: V
-    Double voltage = 2 [(brick_point_class).namespace='https://brickschema.org/schema/1.0.3/Brick#brick', (brick_point_class).value='Voltage_Sensor'];
+    Double voltage = 2 [(brick_point_class).namespace='https://brickschema.org/schema/1.0.3/Brick#', (brick_point_class).value='Voltage_Sensor'];
     //unit: kVA
-    Double apparent_power = 3 [(brick_point_class).namespace='https://brickschema.org/schema/1.0.3/Brick#brick', (brick_point_class).value='Apparent_Power_Sensor'];
+    Double apparent_power = 3 [(brick_point_class).namespace='https://brickschema.org/schema/1.0.3/Brick#', (brick_point_class).value='Apparent_Power_Sensor'];
     //unit: KWh
-    Double energy = 4 [(brick_point_class).namespace='https://brickschema.org/schema/1.0.3/Brick#brick', (brick_point_class).value='Energy_Sensor'];
+    Double energy = 4 [(brick_point_class).namespace='https://brickschema.org/schema/1.0.3/Brick#', (brick_point_class).value='Energy_Sensor'];
 }
 
 message Light {
-    option (brick_equip_class).namespace = 'https://brickschema.org/schema/1.0.3/Brick#brick';
+    option (brick_equip_class).namespace = 'https://brickschema.org/schema/1.0.3/Brick#';
     option (brick_equip_class).value = 'Luminaire';
     // True if the light is on
     //unit: on/off
-    Bool state = 1 [(brick_point_class).namespace='https://brickschema.org/schema/1.0.3/Brick#brick', (brick_point_class).value='Lighting_State'];
+    Bool state = 1 [(brick_point_class).namespace='https://brickschema.org/schema/1.0.3/Brick#', (brick_point_class).value='Lighting_State'];
     // 100 is maximum brightness
-    Int64 brightness = 2 [(brick_point_class).namespace='https://brickschema.org/schema/1.0.3/Brick#brick', (brick_point_class).value='Luminance_Command'];
+    Int64 brightness = 2 [(brick_point_class).namespace='https://brickschema.org/schema/1.0.3/Brick#', (brick_point_class).value='Luminance_Command'];
 }
 
 message EVSE {


### PR DESCRIPTION
In anticipation of integrating the new Obvius driver into xboswave, I've added a couple of new fields to the Meter message within the iot.proto file. The fields I added represent the values that I found most consistently across the building data scraped from the Obvius website.

Some observations + questions:
* There are three main types of substances - water, electricity, and gas
* I was somewhat confused by the different types of "power" metrics for electric meters. I found some definitions that distinguish between each that I thought were helpful
        - (Working) Power [kW]: Power that actually powers the equipment + performs useful work
        - Reactive Power [kVAR]: Power that magnetic equipment needs to produce magnetizing flux
        - Apparent Power [kVA]: Vectorial Summation of kVAR and KW
* Water and Condensation Meters are definitely measuring the same substance, but the data from meters seem to treat the two as separate measurements, resulting in an identical set of fields (total, average rate, instantaneous rate, max, min) for both "water" and "condensation". This means many new fields. My follow up question is whether I should create separate fields for "water" and "condensation" (as it is in the initial commit, i.e. "water_total", "condense_total"), or if I should just keep a single set of the aforementioned fields, and just send separate Meter messages for water and condensation meters.
* The units for water vary between Gallons and Cubic Feet. My initial commit arbitrarily sets Gallons as the unit of measurement, since one can just convert between the two. If Cubic Feet is preferred, I can change it.