### PR TITLE
Improve subscription behavior

### DIFF
--- a/python/pyxbos/pyproject.toml
+++ b/python/pyxbos/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyxbos"
-version = "0.2.13"
+version = "0.2.14"
 description = "Python bindings for XBOS-flavored WAVEMQ and related services"
 authors = ["Gabe Fierro <gtfierro@cs.berkeley.edu>"]
 


### PR DESCRIPTION
Named subscriptions have reliable queues now; can have multiple
callbacks on multiple subscriptions

Also uses functools-partial which seems to behave better for callbacks